### PR TITLE
Use 'dp' from precision_module everywhere

### DIFF
--- a/src/1d/controller_module.f90
+++ b/src/1d/controller_module.f90
@@ -1,4 +1,5 @@
 module controller_module
+    use precision_module, only: dp
 
     implicit none
 
@@ -20,7 +21,7 @@ contains
         ! Locals
         integer :: frame, stat
         integer, allocatable :: no_aux_output(:)
-        real(kind=8) :: dt_out, t_start
+        real(dp) :: dt_out, t_start
 
         ! Log file settings
         integer, parameter :: LOG_UNIT = 213
@@ -55,7 +56,7 @@ contains
         ! Setup time output steps
         if (clawdata%output_style == 1) then
                 dt_out = (clawdata%t_final - clawdata%t0) &
-                                    / real(clawdata%num_output_times,kind=8)
+                                    / real(clawdata%num_output_times, dp)
         end if
 
         ! Open log file

--- a/src/1d/evolve_to_time.f90
+++ b/src/1d/evolve_to_time.f90
@@ -2,18 +2,19 @@ logical function evolve_to_time(t_end, solution, solver, single_step) result(suc
     
     use solution_module, only: solution_type
     use solver_module, only: solver_type, check_CFL
+    use precision_module, only: dp
 
     implicit none
 
     ! Arguments
-    real(kind=8), intent(in) :: t_end
+    real(dp), intent(in) :: t_end
     type(solution_type), intent(in out) :: solution
     type(solver_type), intent(in out) :: solver
     logical, optional, intent(in) :: single_step
 
     ! Locals
     integer :: num_steps
-    real(kind=8) :: t_old, t_new, t_start
+    real(dp) :: t_old, t_new, t_start
 
     character(len=*), parameter :: stat_msg = "('CLAW1... Step',i4,"  // &
                          "'   Courant number =',f6.3,'  dt =',d12.4," // &

--- a/src/1d/hyperbolic_step.f90
+++ b/src/1d/hyperbolic_step.f90
@@ -17,7 +17,7 @@ subroutine hyperbolic_step(solution,solver)
     ! Local storage
     integer :: i, m, mw
     type(geometry_type) :: geometry
-    real(kind=8) :: cfl
+    real(dp) :: cfl
 
     ! Take apart solution and solver data types for ease of reference below
     associate(q => solution%q, aux => solution%aux, f => solver%f,           &

--- a/src/1d/limiter.f90
+++ b/src/1d/limiter.f90
@@ -1,16 +1,17 @@
 subroutine limiter(num_cells, num_ghost, num_eqn, num_waves, wave, s, mthlim)
+    use precision_module, only: dp
     
     implicit none
 
     ! Input
     integer :: num_cells, num_ghost, num_eqn, num_waves
-    real(kind=8), intent(in out) :: wave(num_eqn, num_waves, 1-num_ghost:num_cells + num_ghost)
-    real(kind=8), intent(in out) :: s(num_waves, 1-num_ghost:num_cells + num_ghost)
+    real(dp), intent(in out) :: wave(num_eqn, num_waves, 1-num_ghost:num_cells + num_ghost)
+    real(dp), intent(in out) :: s(num_waves, 1-num_ghost:num_cells + num_ghost)
     integer, intent(in) :: mthlim(num_waves)
 
     ! Locals
     integer :: i, mw
-    real(kind=8) :: dot_product_right, dot_product_left, wave_norm, philim, r
+    real(dp) :: dot_product_right, dot_product_left, wave_norm, philim, r
 
 !     print *, wave
 !     print *, num_cells, num_ghost, num_eqn, num_waves

--- a/src/1d/solution_module.f90
+++ b/src/1d/solution_module.f90
@@ -8,7 +8,7 @@
 
 module solution_module
 
-    use precision_module
+    use precision_module, only: dp
 
     implicit none
 
@@ -17,8 +17,8 @@ module solution_module
         ! Solution extents
         integer :: num_dim, num_eqn, num_aux
         integer, allocatable :: num_cells(:)
-        real(kind=8) :: t
-        real(kind=8), allocatable :: dx(:), lower(:), upper(:), centers(:)
+        real(dp) :: t
+        real(dp), allocatable :: dx(:), lower(:), upper(:), centers(:)
 
         ! Aux array descriptors
         integer :: capa_index
@@ -107,7 +107,7 @@ contains
 
         ! Arguments
         type(solution_type), intent(in out) :: solution
-        real(kind=8), intent(in) :: t
+        real(dp), intent(in) :: t
         integer, intent(in) :: frame
         integer, intent(in) :: q_components(solution%num_eqn)
         integer, intent(in) :: aux_components(solution%num_aux)

--- a/src/1d/solver_module.f90
+++ b/src/1d/solver_module.f90
@@ -9,7 +9,7 @@
 module solver_module
 
     use iso_c_binding, only: c_ptr, C_NULL_PTR
-    use precision_module
+    use precision_module, only: dp
 
     implicit none
 
@@ -72,13 +72,13 @@ module solver_module
         
         ! Status of solver
         integer :: num_steps
-        real(kind=8) :: dt_min, dt_max, cfl, cfl_max, dt
+        real(dp) :: dt_min, dt_max, cfl, cfl_max, dt
 
         ! Solver parameters
         integer :: order, transverse_waves, dimensional_split, source_splitting
         integer :: num_waves, verbosity, steps_max
         integer, allocatable :: limiters(:)
-        real(kind=8) :: dt_max_allowed, cfl_max_allowed, cfl_desired
+        real(dp) :: dt_max_allowed, cfl_max_allowed, cfl_desired
         logical :: use_fwaves, dt_variable
 
         ! Time stepper function controls
@@ -204,14 +204,14 @@ contains
         implicit none
 
         ! Arguments
-        real(kind=8), intent(in) :: t_end
+        real(dp), intent(in) :: t_end
         type(solution_type), intent(in out) :: solution
         type(solver_type), intent(in out) :: solver
         logical, optional, intent(in) :: single_step
 
         ! Locals
         integer :: num_steps
-        real(kind=8) :: t_old, t_new, t_start
+        real(dp) :: t_old, t_new, t_start
 
         character(len=*), parameter :: stat_msg = "('CLAW1... Step',i4,"  // &
                              "'   Courant number =',f6.3,'  dt =',d12.4," // &

--- a/src/1d/source_term.f90
+++ b/src/1d/source_term.f90
@@ -2,10 +2,11 @@ subroutine source_term(t, dt, solution, solver)
     
     use solution_module, only: solution_type
     use solver_module, only: solver_type
+    use precision_module, only: dp
 
     implicit none
 
-    real(kind=8), intent(in) :: t, dt
+    real(dp), intent(in) :: t, dt
     type(solution_type), intent(in out) :: solution
     type(solver_type), intent(in out) :: solver
     

--- a/src/clawdata_module.f90
+++ b/src/clawdata_module.f90
@@ -1,5 +1,6 @@
 module clawdata_module
 
+    use precision_module, only: dp
     implicit none
     
     ! Representation of the clawpack intput data file
@@ -11,23 +12,23 @@ module clawdata_module
 
         ! Domain specification
         integer :: capa_index
-        real(kind=8) :: t0
-        real(kind=8), allocatable :: lower(:), upper(:)
+        real(dp) :: t0
+        real(dp), allocatable :: lower(:), upper(:)
 
         ! Output
         integer :: output_style, num_output_times, output_step_interval
         integer :: total_steps, output_format
         integer, allocatable :: output_q_components(:), output_aux_components(:)
         logical :: output_t0, output_aux_onlyonce
-        real(kind=8) :: t_final
-        real(kind=8), allocatable :: t_out(:)
+        real(dp) :: t_final
+        real(dp), allocatable :: t_out(:)
 
         ! Solver attributes
         integer :: steps_max, order, transverse_waves, dimensional_split
         integer :: source_splitting, num_waves, verbosity
         logical :: dt_variable, use_fwaves
-        real(kind=8) :: cfl_max_allowed, cfl_desired, dt_max_allowed, dt_init
-        real(kind=8), allocatable :: limiters(:)
+        real(dp) :: cfl_max_allowed, cfl_desired, dt_max_allowed, dt_init
+        real(dp), allocatable :: limiters(:)
 
         ! Boundary conditions
         integer :: num_ghost

--- a/tests/advection/main.f90
+++ b/tests/advection/main.f90
@@ -7,6 +7,7 @@ program advection1d
     use controller_module
     use rp1_advection, only: rp1_advection_ptwise, rp1_advection_vectorized
     use rp1_advection, only: rp_type
+    use precision_module, only: dp
 
     use clawdata_module
 
@@ -18,7 +19,7 @@ program advection1d
 
     type(rp_type), target :: rp_aux
 
-    real(kind=8) :: beta
+    real(dp) :: beta
     integer :: i
 
     ! Read in advective speed and initial condition data

--- a/tests/advection/rp1_advection.f90
+++ b/tests/advection/rp1_advection.f90
@@ -1,10 +1,11 @@
 module rp1_advection
 
+    use precision_module, only: dp
     implicit none
     
     type rp_type
         ! Advection speed
-        real(kind=8) :: u
+        real(dp) :: u
     end type rp_type
 
 contains
@@ -15,7 +16,6 @@ contains
 
         use iso_c_binding, only: c_ptr, c_loc, c_f_pointer
         use geometry_module, only: geometry_type
-        use precision_module, only: DP
 
         implicit none
 


### PR DESCRIPTION
One should not use "kind=8" in modern Fortran, but rather have it as a
parameter declared at one place.
