### PR TITLE
Travis-CI: Add initial .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+python:
+  - 2.7
+env:
+  - BUILD_TYPE="Debug"
+  - BUILD_TYPE="Release"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq gfortran liblapack-dev
+before_script:
+  # Print CPU info for debugging purposes:
+  - cat /proc/cpuinfo
+  - gfortran -v
+  - /usr/bin/f95 -v
+  - cmake -DCMAKE_INSTALL_PREFIX="$VIRTUAL_ENV" -DCMAKE_BUILD_TYPE=${BUILD_TYPE} .
+  - make
+  - make install
+script:
+  - ctest --output-on-failure
+notifications:
+  email: false


### PR DESCRIPTION
Once this basic setup works, we'll greatly expand it to also test Python
wrappers and various combination of configuration options.
