### PR TITLE
Add utils.f90 and use stop_error()

### DIFF
--- a/src/1d/boundary_conditions.f90
+++ b/src/1d/boundary_conditions.f90
@@ -2,6 +2,7 @@ subroutine set_boundary_conditions(solution,solver)
 
     use solution_module, only: solution_type
     use solver_module, only: solver_type
+    use utils, only: stop_error
 
     implicit none
 
@@ -17,7 +18,7 @@ subroutine set_boundary_conditions(solution,solver)
         ! Lower boundary
         select case (solver%bc_lower(1))
             case (0)
-                stop "User defined boundary condintion requested but not implemented."
+                call stop_error("User defined boundary condintion requested but not implemented.")
             case (1)
                 ! Zero-order extrapolation
                 forall (i=1:num_ghost)
@@ -41,7 +42,7 @@ subroutine set_boundary_conditions(solution,solver)
         ! Upper boundary
         select case (solver%bc_upper(1))
             case (0)
-                stop "User defined boundary condintion requested but not implemented."
+                call stop_error("User defined boundary condintion requested but not implemented.")
             case (1)
                 ! Zero-order extrapolation
                 forall (i=1:num_ghost)

--- a/src/1d/controller_module.f90
+++ b/src/1d/controller_module.f90
@@ -1,5 +1,6 @@
 module controller_module
     use precision_module, only: dp
+    use utils, only: stop_error, str
 
     implicit none
 
@@ -37,7 +38,7 @@ contains
 
         ! No auxillary output array
         allocate(no_aux_output(solution%num_aux), stat=stat)
-        if (stat /= 0) stop "Not able to allocate work array!"
+        if (stat /= 0) call stop_error("Not able to allocate work array!")
         no_aux_output = 0
 
         ! Output initial time if requested
@@ -62,9 +63,7 @@ contains
         ! Open log file
         open(unit=LOG_UNIT, file=LOG_FILE_NAME, iostat=stat, status="unknown", action="write")
         if ( stat /= 0 ) then
-            print *, "Error opening log file with error ",stat
-            success = .false.
-            stop
+            call stop_error("Error opening log file with error " // str(stat))
         endif
 
         ! Primary output loop

--- a/src/1d/hyperbolic_step.f90
+++ b/src/1d/hyperbolic_step.f90
@@ -7,6 +7,7 @@ subroutine hyperbolic_step(solution,solver)
     use precision_module, only: dp
     use geometry_module, only: geometry_type
     use solver_module, only: solver_type
+    use utils, only: stop_error
 
     implicit none
 
@@ -74,7 +75,7 @@ subroutine hyperbolic_step(solution,solver)
                                       apdq(:,i))
             end do
         else
-            stop "No Riemann solver function specified."
+            call stop_error("No Riemann solver function specified.")
         endif
 
         ! Modify q for Godunov update

--- a/src/1d/limiter.f90
+++ b/src/1d/limiter.f90
@@ -1,5 +1,6 @@
 subroutine limiter(num_cells, num_ghost, num_eqn, num_waves, wave, s, mthlim)
     use precision_module, only: dp
+    use utils, only: stop_error
     
     implicit none
 
@@ -16,7 +17,7 @@ subroutine limiter(num_cells, num_ghost, num_eqn, num_waves, wave, s, mthlim)
 !     print *, wave
 !     print *, num_cells, num_ghost, num_eqn, num_waves
 !     print *, size(wave)
-!     stop "Wave is coming in as partially NaNs!"
+!     call stop_error("Wave is coming in as partially NaNs!")
 
     do mw=1,num_waves
         if (mthlim(mw) /= 0) then
@@ -56,7 +57,7 @@ subroutine limiter(num_cells, num_ghost, num_eqn, num_waves, wave, s, mthlim)
                         philim = r
 
                     case default
-                        stop "*** ERROR *** Invalid limiter requested."
+                        call stop_error("*** ERROR *** Invalid limiter requested.")
                 end select
 
                 wave(:,mw,i) = philim * wave(:,mw,i)

--- a/src/1d/rp1_interface.f90
+++ b/src/1d/rp1_interface.f90
@@ -34,6 +34,7 @@ contains
 
         use solver_module, only: DP, DP, DP
         use solution_module, only: DP, DP
+        use utils, only: stop_error
 
         implicit none
 
@@ -50,7 +51,7 @@ contains
         real(kind=DP), intent(in out) :: amdq(num_eqn,1-num_ghost:num_cells+num_ghost)
         real(kind=DP), intent(in out) :: apdq(num_eqn,1-num_ghost:num_cells+num_ghost)
 
-        stop "You must provide a valid Riemann solver!"
+        call stop_error("You must provide a valid Riemann solver!")
 
     end subroutine rp1
 

--- a/src/1d/solution_module.f90
+++ b/src/1d/solution_module.f90
@@ -9,6 +9,7 @@
 module solution_module
 
     use precision_module, only: dp
+    use utils, only: stop_error
 
     implicit none
 
@@ -55,7 +56,7 @@ contains
         ! Set new solution object's array extents
         self%num_dim = clawdata%num_dim
         allocate(self%num_cells(self%num_dim), stat=stat)
-        if (stat /= 0) stop "Allocation request denied for num_cells"
+        if (stat /= 0) call stop_error("Allocation request denied for num_cells")
         self%num_cells = clawdata%num_cells
         self%num_eqn = clawdata%num_eqn
         self%num_aux = clawdata%num_aux
@@ -82,16 +83,16 @@ contains
 
             ! Allocate primary arrays
             allocate(self%q(num_eqn,1-num_ghost:num_cells+num_ghost),stat=stat)
-            if (stat /= 0) stop "Allocation of solutions's q array failed!"
+            if (stat /= 0) call stop_error("Allocation of solutions's q array failed!")
             allocate(self%aux(num_aux,1-num_ghost:num_cells+num_ghost),stat=stat)
-            if (stat /= 0) stop "Allocation of solutions's aux array failed!"
+            if (stat /= 0) call stop_error("Allocation of solutions's aux array failed!")
 
             ! Calculated values
             allocate(self%dx(self%num_dim), stat=stat)
-            if (stat /= 0) stop "Allocation of solution's dx array failed!"
+            if (stat /= 0) call stop_error("Allocation of solution's dx array failed!")
             self%dx(1) = (self%upper(1) - self%lower(1)) / num_cells
             allocate(self%centers(1-num_ghost:num_cells+num_ghost),stat=stat)
-            if (stat /= 0) stop "Allocation of solutions's centers array failed!"
+            if (stat /= 0) call stop_error("Allocation of solutions's centers array failed!")
             forall(i=1-num_ghost:num_cells+num_ghost)
                 self%centers(i) = self%lower(1) + (i-0.5d0) * self%dx(1)
             end forall
@@ -175,7 +176,7 @@ contains
 
         ! Output the aux array if requested
         if (.not.all(aux_components == 0)) then
-            stop "Outputting the aux array not supported yet!"
+            call stop_error("Outputting the aux array not supported yet!")
         end if
         
     end subroutine output_solution

--- a/src/1d/solver_module.f90
+++ b/src/1d/solver_module.f90
@@ -10,6 +10,7 @@ module solver_module
 
     use iso_c_binding, only: c_ptr, C_NULL_PTR
     use precision_module, only: dp
+    use utils, only: stop_error
 
     implicit none
 
@@ -175,17 +176,17 @@ contains
 
         ! Based on number of waves and solution parameters allocate work arrays
         allocate(self%f(num_eqn,1-num_ghost:num_cells+num_ghost),stat=stat)
-        if (stat /= 0) stop "Allocation of f failed."
+        if (stat /= 0) call stop_error("Allocation of f failed.")
         allocate(self%apdq(num_eqn,1-num_ghost:num_cells+num_ghost),stat=stat)
-        if (stat /= 0) stop "Allocation of apdq failed."
+        if (stat /= 0) call stop_error("Allocation of apdq failed.")
         allocate(self%amdq(num_eqn,1-num_ghost:num_cells+num_ghost),stat=stat)
-        if (stat /= 0) stop "Allocation of amdq failed."
+        if (stat /= 0) call stop_error("Allocation of amdq failed.")
         allocate(self%wave(num_eqn,num_waves,1-num_ghost:num_cells+num_ghost),stat=stat)
-        if (stat /= 0) stop "Allocation of wave failed."
+        if (stat /= 0) call stop_error("Allocation of wave failed.")
         allocate(self%s(num_waves,1-num_ghost:num_cells+num_ghost),stat=stat)
-        if (stat /= 0) stop "Allocation of s failed."
+        if (stat /= 0) call stop_error("Allocation of s failed.")
         allocate(self%dtdx(1-num_ghost:num_cells+num_ghost),stat=stat)
-        if (stat /= 0) stop "Allocation of dtdx failed."
+        if (stat /= 0) call stop_error("Allocation of dtdx failed.")
         
         end associate
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SRC
     clawdata_module.f90  open_data_file.f90  precision_module.f90
+    utils.f90
 
     1d/before_step.f90          1d/hyperbolic_step.f90  1d/solution_module.f90
     1d/boundary_conditions.f90  1d/limiter.f90          1d/solver_module.f90

--- a/src/clawdata_module.f90
+++ b/src/clawdata_module.f90
@@ -1,6 +1,7 @@
 module clawdata_module
 
     use precision_module, only: dp
+    use utils, only: stop_error
     implicit none
     
     ! Representation of the clawpack intput data file
@@ -70,20 +71,20 @@ contains
         ! Begin reading file
         read(iounit,'(i2)') self%num_dim
         if (self%num_dim /= 1) then
-            stop "Dimension is not 1, wrong data source files used."
+            call stop_error("Dimension is not 1, wrong data source files used.")
         end if
         
         ! Domain
         allocate(self%lower(self%num_dim), stat=err)
-        if (err /= 0) stop "*** ERROR *** - Allocation request denied."
+        if (err /= 0) call stop_error("*** ERROR *** - Allocation request denied.")
         read(iounit,*) self%lower
         allocate(self%upper(self%num_dim), stat=err)
-        if (err /= 0) stop "*** ERROR *** - Allocation request denied."
+        if (err /= 0) call stop_error("*** ERROR *** - Allocation request denied.")
         read(iounit,*) self%upper
         allocate(self%num_cells(self%num_dim), stat=err)
-        if (err /= 0) stop "*** ERROR *** - Allocation request denied."
+        if (err /= 0) call stop_error("*** ERROR *** - Allocation request denied.")
         read(iounit,*) self%num_cells
-        if (.not. all(self%num_cells > 0, dim=1)) stop "Need number of cells > 0."
+        if (.not. all(self%num_cells > 0, dim=1)) call stop_error("Need number of cells > 0.")
         read(iounit,*)
 
         ! Base array sizes
@@ -106,7 +107,7 @@ contains
         else if (self%output_style == 2) then
             read(iounit,*) self%num_output_times
             allocate(self%t_out(self%num_output_times),stat=stat)
-            if (stat /= 0) stop "Allocation of t_out failed!"
+            if (stat /= 0) call stop_error("Allocation of t_out failed!")
             read(iounit,*) (self%t_out(i), i=1,self%num_output_times)
 
         else if (self%output_style == 3) then
@@ -116,16 +117,16 @@ contains
             self%num_output_times = self%total_steps
 
         else
-            stop "Output style > 3 unimplemented."
+            call stop_error("Output style > 3 unimplemented.")
         end if
         read(iounit,*)
 
         ! Output details
         read(iounit,*) self%output_format
         allocate(self%output_q_components(self%num_eqn), stat=stat)
-        if (stat /= 0) stop "Allocation of output_q_components failed!" 
+        if (stat /= 0) call stop_error("Allocation of output_q_components failed!" )
         allocate(self%output_aux_components(self%num_aux), stat=stat)
-        if (stat /= 0) stop "Allocation of output_aux_components failed!" 
+        if (stat /= 0) call stop_error("Allocation of output_aux_components failed!" )
         read(iounit,*) self%output_q_components
         if (self%num_aux > 0) then
             read(iounit,*) self%output_aux_components
@@ -156,17 +157,17 @@ contains
 
         ! Limiters to be used
         allocate(self%limiters(self%num_waves),stat=stat)
-        if (stat /= 0) stop "Allocation of limiters array failed!"
+        if (stat /= 0) call stop_error("Allocation of limiters array failed!")
         read(iounit,*) (self%limiters(mw), mw=1,self%num_waves)
         read(iounit,*)
 
         ! Boundary conditions
         read(iounit,*) self%num_ghost
         allocate(self%bc_lower(self%num_dim), stat=stat)
-        if (stat /= 0) stop "Allocation of bc_lower failed!"
+        if (stat /= 0) call stop_error("Allocation of bc_lower failed!")
         read(iounit,*) self%bc_lower
         allocate(self%bc_upper(self%num_dim), stat=stat)
-        if (stat /= 0) stop "Allocation of bc_upper failed!"
+        if (stat /= 0) call stop_error("Allocation of bc_upper failed!")
         read(iounit,*) self%bc_upper
         if ((self%bc_lower(1) == 2 .and. self%bc_upper(1) /= 2) .or.  &
             (self%bc_lower(1) /= 2 .and. self%bc_upper(1) == 2)) then

--- a/src/open_data_file.f90
+++ b/src/open_data_file.f90
@@ -5,7 +5,7 @@
 ! All comment lines must start with # in the first column.
 
 subroutine open_data_file(iounit, fname)
-
+    use utils, only: stop_error
     implicit none
 
     ! Arguments
@@ -29,8 +29,7 @@ subroutine open_data_file(iounit, fname)
         ! #write(6,*) 'truncated fname12 = XXX',fname12,'XXX'
         ! inquire(file=fname12,exist=foundFile)
         if (.not. foundFile) then
-            print "(2a)",'*** in opendatafile, file not found:', fname 
-            stop
+            call stop_error('*** in opendatafile, file not found: ' // fname)
         endif
         ! open(unit=iounit,file=fname12,status='old',form='formatted')
         ! write(6,*) 'Reading data file: ', fname12

--- a/src/utils.f90
+++ b/src/utils.f90
@@ -1,0 +1,76 @@
+module utils
+use precision_module, only: dp
+implicit none
+private
+public stop_error, str
+
+interface str
+    module procedure str_int, str_real, str_real_n
+end interface
+
+contains
+
+subroutine stop_error(msg)
+! Aborts the program with nonzero exit code
+!
+! The statement "stop msg" will return 0 exit code when compiled using
+! gfortran. stop_error() uses the statement "stop 1" which returns an exit code
+! 1 and a print statement to print the message.
+!
+! Example
+! -------
+!
+! call stop_error("Invalid argument")
+
+character(len=*) :: msg ! Message to print on stdout
+print *, msg
+stop 1
+end subroutine
+
+pure integer function str_int_len(i) result(sz)
+! Returns the length of the string representation of 'i'
+integer, intent(in) :: i
+integer, parameter :: MAX_STR = 100
+character(MAX_STR) :: s
+! If 's' is too short (MAX_STR too small), Fortan will abort with:
+! "Fortran runtime error: End of record"
+write(s, '(i0)') i
+sz = len_trim(s)
+end function
+
+pure function str_int(i) result(s)
+! Converts integer "i" to string
+integer, intent(in) :: i
+character(len=str_int_len(i)) :: s
+write(s, '(i0)') i
+end function
+
+pure integer function str_real_len(r, fmt) result(sz)
+! Returns the length of the string representation of 'i'
+real(dp), intent(in) :: r
+character(len=*), intent(in) :: fmt
+integer, parameter :: MAX_STR = 100
+character(MAX_STR) :: s
+! If 's' is too short (MAX_STR too small), Fortan will abort with:
+! "Fortran runtime error: End of record"
+write(s, fmt) r
+sz = len_trim(s)
+end function
+
+pure function str_real(r) result(s)
+! Converts the real number "r" to string with 7 decimal digits.
+real(dp), intent(in) :: r
+character(len=*), parameter :: fmt="(f0.6)"
+character(len=str_real_len(r, fmt)) :: s
+write(s, fmt) r
+end function
+
+pure function str_real_n(r, n) result(s)
+! Converts the real number "r" to string with 'n' decimal digits.
+real(dp), intent(in) :: r
+integer, intent(in) :: n
+character(len=str_real_len(r, "(f0." // str_int(n) // ")")) :: s
+write(s, "(f0." // str_int(n) // ")") r
+end function
+
+end module


### PR DESCRIPTION
The main problem is, that we need to test in our test suite that the library
works. If the library exits using:

```
stop "some error message"
```

Then the main program will still exit with a zero exit code, so our test suite
passes... To fix this, one should use the "stop_error" subroutine:

```
call stop_error("some error message")
```

That subroutine prints the message and calls "stop 1", which actually returns
a non-zero exit code and our test suite will fail.

Note that after this patch, our test will fail with a non-zero exit code and
Travis test will thus fail.
