### PR TITLE
Travis: remove the -qq from apt-get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
   - BUILD_TYPE="Debug"
   - BUILD_TYPE="Release"
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq gfortran liblapack-dev
+  - sudo apt-get update
+  - sudo apt-get install gfortran liblapack-dev
 before_script:
   # Print CPU info for debugging purposes:
   - cat /proc/cpuinfo


### PR DESCRIPTION
That way we know exactly where things stalled, as sometimes it takes a long
time to download/install the packages for whatever reason, e.g. here it took 4
minutes what normally takes about 10s:

https://travis-ci.org/clawpack/classic/jobs/9107912
