### PR TITLE
Travis: setup input file for our test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - git submodule init
   - git submodule update clawutil visclaw riemann
   - python setup.py install
+  - cd ..
 before_script:
   # Print CPU info for debugging purposes:
   - cat /proc/cpuinfo


### PR DESCRIPTION
This is now ready to be merged.

TODO:
- [x] properly install all dependencies, so that `setrun.py` generates the input file for our test.
