### PR TITLE
Switching to 3D-style interpretation of dt_variable

### DIFF
--- a/src/1d/claw1ez.f
+++ b/src/1d/claw1ez.f
@@ -116,7 +116,11 @@ c
       read(55,*) nv(1)      ! Maximum number of steps
 
       read(55,*) dt_variable    ! Variable or fixed dt
-      method(1) = (dt_variable .eqv. .true.)
+      if (dt_variable) then
+         method(1) = 1
+      else
+         method(1) = 0
+      end if
       read(55,*) method(2)    ! Order
       ! method(3) (transverse order) not used in 1D
       ! No dimensional splitting in 1D

--- a/src/2d/claw2ez.f
+++ b/src/2d/claw2ez.f
@@ -112,7 +112,11 @@ c
       read(55,*) nv(1)      ! Maximum number of steps
 
       read(55,*) dt_variable    ! Variable or fixed dt
-      method(1) = (dt_variable .eqv. .true.)
+      if (dt_variable) then
+         method(1) = 1
+      else
+         method(1) = 0
+      end if
       read(55,*) method(2)    ! Order
       read(55,*) method(3)    ! Transverse propagation style
       read(55,*) dimensional_split    ! Whether to use dimensional splitting


### PR DESCRIPTION
Switching to 3D style after gfortran complaint that assigning from a logical to an integer is an extension, not a standard language feature.
