### PR TITLE
Updating comments, making chkmth slightly more proper

### DIFF
--- a/src/1d/claw1.f
+++ b/src/1d/claw1.f
@@ -75,16 +75,16 @@ c       physical domain.  In addition there are mbc grid cells
 c       along each edge of the grid that are used for boundary
 c       conditions.
 c 
-c    q(1-mbc:mx+mbc, meqn) 
+c    q(meqn, 1-mbc:mx+mbc) 
 c        On input:  initial data at time tstart.
 c        On output: final solution at time tend.
-c        q(i,m) = value of mth component in the i'th cell.
-c        Values within the physical domain are in q(i,m) 
+c        q(m,i) = value of mth component in the i'th cell.
+c        Values within the physical domain are in q(m,i) 
 c                for i = 1,2,...,mx
 c        mbc extra cells on each end are needed for boundary conditions
 c        as specified in the routine bc1.
 c
-c    aux(1-mbc:mx+mbc, maux)
+c    aux(maux, 1-mbc:mx+mbc)
 c        Array of auxiliary variables that are used in specifying the problem.
 c        If method(7) = 0 then there are no auxiliary variables and aux
 c                         can be a dummy variable.
@@ -99,7 +99,7 @@ c
 c        If method(6) = 0 then there is no capacity function.
 c        If method(6) = mcapa > 0  then there is a capacity function and
 c            capa(i), the "capacity" of the i'th cell, is assumed to be
-c            stored in aux(i,mcapa).
+c            stored in aux(mcapa,i).
 c            In this case we require method(7).ge.mcapa.
 c
 c    dx = grid spacing in x.  
@@ -247,10 +247,10 @@ c         1:mx to the mbc ghost cells along each edge of the domain.
 c
 c          The form of this subroutine is
 c  -------------------------------------------------
-c     subroutine bc1(meqn,mbc,mx,xlower,dx,q,maux,aux,t,mthbc)
+c     subroutine bc1(meqn,mbc,mx,xlower,dx,q,maux,aux,t,dt,mthbc)
 c     implicit double precision (a-h,o-z)
-c     dimension   q(1-mbc:mx+mbc, meqn)
-c     dimension aux(1-mbc:mx+mbc, *)
+c     dimension   q(meqn, 1-mbc:mx+mbc)
+c     dimension aux(maux, 1-mbc:mx+mbc)
 c     dimension mthbc(2)
 c  -------------------------------------------------
 c
@@ -262,16 +262,16 @@ c    rp1 = user-supplied subroutine that implements the Riemann solver
 c
 c          The form of this subroutine is
 c  -------------------------------------------------
-c     subroutine rp1(meqn,mwaves,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apdq)
+c     subroutine rp1(meqn,mwaves,mbc,mx,ql,qr,auxl,auxr,wave,s,amdq,apdq,maux)
 c     implicit double precision (a-h,o-z)
-c     dimension   ql(1-mbc:mx+mbc, meqn)
-c     dimension   qr(1-mbc:mx+mbc, meqn)
-c     dimension auxl(1-mbc:mx+mbc, *)
-c     dimension auxr(1-mbc:mx+mbc, *)
-c     dimension wave(1-mbc:mx+mbc, meqn, mwaves)
-c     dimension    s(1-mbc:mx+mbc, mwaves)
-c     dimension amdq(1-mbc:mx+mbc, meqn)
-c     dimension apdq(1-mbc:mx+mbc, meqn)
+c     dimension   ql(meqn, 1-mbc:mx+mbc)
+c     dimension   qr(meqn, 1-mbc:mx+mbc)
+c     dimension auxl(maux, 1-mbc:mx+mbc)
+c     dimension auxr(maux, 1-mbc:mx+mbc)
+c     dimension wave(meqn, mwaves, 1-mbc:mx+mbc)
+c     dimension    s(mwaves, 1-mbc:mx+mbc)
+c     dimension amdq(meqn, 1-mbc:mx+mbc)
+c     dimension apdq(meqn, 1-mbc:mx+mbc)
 c  -------------------------------------------------
 c
 c         On input, ql contains the state vector at the left edge of each cell
@@ -279,8 +279,8 @@ c                   qr contains the state vector at the right edge of each cell
 c                 auxl contains auxiliary values at the left edge of each cell
 c                 auxr contains auxiliary values at the right edge of each cell
 c
-c         Note that the i'th Riemann problem has left state qr(i-1,:)
-c                                            and right state ql(i,:)
+c         Note that the i'th Riemann problem has left state qr(:,i-1)
+c                                            and right state ql(:,i)
 c         In the standard clawpack routines, this Riemann solver is
 c         called with ql=qr=q along this slice.  More flexibility is allowed
 c         in case the user wishes to implement another solution method
@@ -291,12 +291,12 @@ c         are passed in using auxl and auxr.  Again, in the standard routines
 c         auxl=auxr=aux in the call to rp1.
 c
 c          On output, 
-c              wave(i,m,mw) is the m'th component of the jump across
+c              wave(m,mw,i) is the m'th component of the jump across
 c                              wave number mw in the ith Riemann problem.
-c              s(i,mw) is the wave speed of wave number mw in the
+c              s(mw,i) is the wave speed of wave number mw in the
 c                              ith Riemann problem.
-c              amdq(i,m) = m'th component of A^- Delta q,
-c              apdq(i,m) = m'th component of A^+ Delta q,
+c              amdq(m,i) = m'th component of A^- Delta q,
+c              apdq(m,i) = m'th component of A^+ Delta q,
 c                     the decomposition of the flux difference
 c                         f(qr(i-1)) - f(ql(i))
 c                     into leftgoing and rightgoing parts respectively.
@@ -318,18 +318,18 @@ c           claw/clawpack/1d/lib/src1.f)
 c
 c          The form of this subroutine is
 c  -------------------------------------------------
-c     subroutine src1(mx,meqn,mbc,mx,xlower,dx,q,maux,aux,t,dt)
+c     subroutine src1(meqn,mbc,mx,xlower,dx,q,maux,aux,t,dt)
 c     implicit double precision (a-h,o-z)
-c     dimension   q(1-mbc:mx+mbc, meqn)
-c     dimension aux(1-mbc:mx+mbc, *)
+c     dimension   q(meqn, 1-mbc:mx+mbc)
+c     dimension aux(maux, 1-mbc:mx+mbc)
 c  -------------------------------------------------
 c      If method(7)=0  or the auxiliary variables are not needed in this solver,
 c      then the latter dimension statement can be omitted, but aux should
 c      still appear in the argument list.
 c
-c      On input, q(i,m) contains the data for solving the
+c      On input, q(m,i) contains the data for solving the
 c                source term equation.
-c      On output, q(i,m) should have been replaced by the solution to
+c      On output, q(m,i) should have been replaced by the solution to
 c                 the source term equation after a step of length dt.
 c
 c
@@ -340,10 +340,10 @@ c
 c          The form of this subroutine is
 c      
 c  -------------------------------------------------
-c      subroutine b4step1(mx,mbc,mx,meqn,q,xlower,dx,time,dt,maux,aux)
+c      subroutine b4step1(mbc,mx,meqn,q,xlower,dx,time,dt,maux,aux)
 c      implicit double precision (a-h,o-z)
-c      dimension   q(1-mbc:mx+mbc, meqn)
-c      dimension aux(1-mbc:mx+mbc, *)
+c      dimension   q(meqn, 1-mbc:mx+mbc)
+c      dimension aux(maux, 1-mbc:mx+mbc)
 c  -------------------------------------------------
 c
 c

--- a/src/1d/claw1ez.f
+++ b/src/1d/claw1ez.f
@@ -9,8 +9,7 @@ c     An easy-to-use clawpack driver routine for simple applications
 c     Documentation is available at
 c                 http://www.amath.washington.edu/~claw/doc.html
 c
-c     Author: Randall J. LeVeque
-c     Version of August, 2002 --  CLAWPACK Version 4.1
+c     Authors: Randall J. LeVeque, Grady I. Lemoine
 c
       implicit double precision (a-h,o-z)
       external bc1,rp1,src1,b4step1

--- a/src/1d/rp1.f
+++ b/src/1d/rp1.f
@@ -17,8 +17,8 @@ c     #            s the speeds,
 c     #            amdq the  left-going flux difference  A^- \Delta q
 c     #            apdq the right-going flux difference  A^+ \Delta q
 c
-c     # Note that the i'th Riemann problem has left state qr(i-1,:)
-c     #                                    and right state ql(i,:)
+c     # Note that the i'th Riemann problem has left state qr(:,i-1)
+c     #                                    and right state ql(:,i)
 c     # From the basic clawpack routine step1, rp is called with ql = qr = q.
 c
 c

--- a/src/1d/step1.f90
+++ b/src/1d/step1.f90
@@ -14,22 +14,22 @@
 
 !     amdq, apdq, wave, s, and f are used locally:
 
-!     amdq(1-num_ghost:mx+num_ghost, num_eqn) = left-going flux-differences
-!     apdq(1-num_ghost:mx+num_ghost, num_eqn) = right-going flux-differences
+!     amdq(num_eqn, 1-num_ghost:mx+num_ghost) = left-going flux-differences
+!     apdq(num_eqn, 1-num_ghost:mx+num_ghost) = right-going flux-differences
 !        e.g. amdq(m,i) = m'th component of A^- \Delta q from i'th Riemann
 !                         problem (between cells i-1 and i).
 
-!     wave(1-num_ghost:mx+num_ghost, num_eqn, num_waves) = waves from solution of
+!     wave(num_eqn, num_waves, 1-num_ghost:mx+num_ghost) = waves from solution of
 !                                           Riemann problems,
 !            wave(m,mw,i) = mth component of jump in q across
 !                           wave in family mw in Riemann problem between
 !                           states i-1 and i.
 
-!     s(1-num_ghost:mx+num_ghost, num_waves) = wave speeds,
+!     s(num_waves, 1-num_ghost:mx+num_ghost) = wave speeds,
 !            s(m,iw) = speed of wave in family mw in Riemann problem between
 !                      states i-1 and i.
 
-!     f(1-num_ghost:mx+num_ghost, num_eqn) = correction fluxes for second order method
+!     f(num_eqn, 1-num_ghost:mx+num_ghost) = correction fluxes for second order method
 !            f(m,i) = mth component of flux at left edge of ith cell
 !     --------------------------------------------------------------------
 

--- a/src/2d/claw2ez.f
+++ b/src/2d/claw2ez.f
@@ -9,8 +9,7 @@ c     An easy-to-use clawpack driver routine for simple applications
 c     Documentation is available at
 c                 http://www.amath.washington.edu/~claw/doc.html
 c
-c     Author: Randall J. LeVeque
-c     Version of August, 2002 --  CLAWPACK Version 4.1
+c     Authors: Randall J. LeVeque, Grady I. Lemoine
 c
       implicit double precision (a-h,o-z)
       external bc2,rpn2,rpt2,src2,b4step2

--- a/src/2d/driver.f90
+++ b/src/2d/driver.f90
@@ -1,4 +1,4 @@
-!  Generic driver routine for 3D Clawpack 5.0, using claw2ez
+!  Generic driver routine for 2D Clawpack 5.0, using claw2ez
 !  Allocation has been moved int claw2ez; this file essentially
 !  does nothing, but is being retained because it gives the
 !  codebase more flexibility.

--- a/src/2d/flux2.f90
+++ b/src/2d/flux2.f90
@@ -16,9 +16,9 @@
 !     # go into the arrays fadd and gadd.  The notation is written assuming
 !     # we are solving along a 1D slice in the x-direction.
 
-!     # fadd(i,.) modifies F to the left of cell i
-!     # gadd(i,.,1) modifies G below cell i
-!     # gadd(i,.,2) modifies G above cell i
+!     # fadd(:,i) modifies F to the left of cell i
+!     # gadd(:,i,1) modifies G below cell i
+!     # gadd(:,i,2) modifies G above cell i
 
 !     # The method used is specified by method(2:3):
 
@@ -44,7 +44,7 @@
 !                  = dt/(dy*capa(icom,j))  if method(6) = 1
 
 !     Notation:
-!        The jump in q (q1d(i,:)-q1d(i-1,:))  is split by rpn2 into
+!        The jump in q (q1d(:,i)-q1d(:,i-1))  is split by rpn2 into
 !            amdq =  the left-going flux difference  A^- Delta q
 !            apdq = the right-going flux difference  A^+ Delta q
 !        Each of these is split by rpt2 into

--- a/src/2d/rpn2.f
+++ b/src/2d/rpn2.f
@@ -26,8 +26,8 @@ c     #                       f(qr(i-1)) - f(ql(i))
 c     #                   into leftgoing and rightgoing parts respectively.
 c     #               
 c
-c     # Note that the i'th Riemann problem has left state qr(i-1,:)
-c     #                                    and right state ql(i,:)
+c     # Note that the i'th Riemann problem has left state qr(:,i-1)
+c     #                                    and right state ql(:,i)
 c     # From the basic clawpack routines, this routine is called with ql = qr
 c     # maux=0 and aux arrays are unused in this example.
 c

--- a/src/3d/chkmth.f
+++ b/src/3d/chkmth.f
@@ -8,7 +8,7 @@ c     # Note that method(3) < 0 yields dimensional splitting.
 c
       implicit double precision (a-h,o-z)
 c
-      dimension method(*)
+      dimension method(7)
 c
       info = 0
 c

--- a/src/3d/claw3.f
+++ b/src/3d/claw3.f
@@ -117,7 +117,7 @@ c
 c        If method(6) = 0 then there is no capacity function.
 c        If method(6) = mcapa > 0  then there is a capacity function and
 c            capa(i,j,k), the "capacity" of the (i,j,k) cell, is assumed to be
-c            stored in aux(i,j,k,mcapa).
+c            stored in aux(mcapa,i,j,k).
 c            In this case we require method(7).ge.mcapa.
 c
 c    dx = grid spacing in x.
@@ -220,7 +220,7 @@ c                       the subroutine src2 must be provided.
 c
 c         method(6) = 0 if there is no capacity function capa.
 c                   = mcapa > 0 if there is a capacity function.  In this case
-c                       aux(i,j,k,mcapa) is the capacity of cell (i,j,k)
+c                       aux(mcapa,i,j,k) is the capacity of cell (i,j,k)
 c                       and you must also specify method(7) .ge. mcapa
 c                       and set aux.
 c
@@ -297,14 +297,14 @@ c  ---------------------------------------------------------------------
 c     subroutine rpn3(ixyz,maxm,meqn,mwaves,mbc,mx,ql,qr,
 c    &                  auxl,auxr,maux,wave,s,amdq,apdq)
 c    implicit double precision (a-h,o-z)
-c     dimension wave(1-mbc:maxm+mbc, meqn, mwaves)
-c     dimension    s(1-mbc:maxm+mbc, mwaves)
-c     dimension   ql(1-mbc:maxm+mbc, meqn)
-c     dimension   qr(1-mbc:maxm+mbc, meqn)
-c     dimension amdq(1-mbc:maxm+mbc, meqn)
-c     dimension apdq(1-mbc:maxm+mbc, meqn)
-c     dimension auxl(1-mbc:maxm+mbc, maux, 3)
-c     dimension auxr(1-mbc:maxm+mbc, maux, 3)
+c     dimension wave(mwaves, meqn, 1-mbc:maxm+mbc)
+c     dimension    s(mwaves, 1-mbc:maxm+mbc)
+c     dimension   ql(meqn, 1-mbc:maxm+mbc)
+c     dimension   qr(meqn, 1-mbc:maxm+mbc)
+c     dimension amdq(meqn, 1-mbc:maxm+mbc)
+c     dimension apdq(meqn, 1-mbc:maxm+mbc)
+c     dimension auxl(maux, 1-mbc:maxm+mbc)
+c     dimension auxr(maux, 1-mbc:maxm+mbc)
 c  ---------------------------------------------------------------------
 c         solve Riemann problems along one slice of data.
 c         This data is along a slice in the x-direction if ixyz=1
@@ -314,14 +314,11 @@ c
 c         On input, ql contains the state vector at the left edge of each cell
 c                   qr contains the state vector at the right edge of each cell
 c
-c         auxl(i,ma,2) contains auxiliary data for cells along this slice,
+c         auxl(ma,i) contains auxiliary data for cells along this slice,
 c            where ma=1,maux in the case where maux=method(7) > 0.
-c         auxl(i,ma,1) and auxl(i,ma,3) contain auxiliary data along
-c         neighboring slices that generally aren't needed in the rpn3 routine.
 c
-c
-c         Note that the i'th Riemann problem has left state qr(i-1,:)
-c                                            and right state ql(i,:)
+c         Note that the i'th Riemann problem has left state qr(:,i-1)
+c                                            and right state ql(:,i)
 c         From the basic clawpack routines, this routine is called with ql = qr
 c
 c         More flexibility is allowed
@@ -330,13 +327,13 @@ c         that requires left and rate states at each interface.
 c
 c
 c          On output,
-c             wave(i,m,mw) is the mth component of the jump across
+c             wave(m,mw,i) is the mth component of the jump across
 c                              wave number mw in the ith Riemann problem.
-c             s(i,mw) is the wave speed of wave number mw in the
+c             s(mw,i) is the wave speed of wave number mw in the
 c                              ith Riemann problem.
-c             amdq(i,m) is the m'th component of the left-going flux
+c             amdq(m,i) is the m'th component of the left-going flux
 c                       difference.
-c             apdq(i,m) is the m'th component of the right-going flux
+c             apdq(m,i) is the m'th component of the right-going flux
 c                       difference.
 c           It is assumed that each wave consists of a jump discontinuity
 c           propagating at a single speed, as results, for example, from a
@@ -352,14 +349,14 @@ c     subroutine rpt3(ixyz,icoor,maxm,meqn,mwaves,mbc,mx,
 c    &                  ql,qr,aux1,aux2,aux3,maux,imp,asdq,
 c    &                  bmasdq,bpasdq)
 c     implicit double precision (a-h,o-z)
-c     dimension     ql(1-mbc:maxm+mbc, meqn)
-c     dimension     qr(1-mbc:maxm+mbc, meqn)
-c     dimension   asdq(1-mbc:maxm+mbc, meqn)
-c     dimension bmasdq(1-mbc:maxm+mbc, meqn)
-c     dimension bpasdq(1-mbc:maxm+mbc, meqn)
-c     dimension   aux1(1-mbc:maxm+mbc, maux, 3)
-c     dimension   aux2(1-mbc:maxm+mbc, maux, 3)
-c     dimension   aux3(1-mbc:maxm+mbc, maux, 3)
+c     dimension     ql(meqn, 1-mbc:maxm+mbc)
+c     dimension     qr(meqn, 1-mbc:maxm+mbc)
+c     dimension   asdq(meqn, 1-mbc:maxm+mbc)
+c     dimension bmasdq(meqn, 1-mbc:maxm+mbc)
+c     dimension bpasdq(meqn, 1-mbc:maxm+mbc)
+c     dimension   aux1(maux, 1-mbc:maxm+mbc, 3)
+c     dimension   aux2(maux, 1-mbc:maxm+mbc, 3)
+c     dimension   aux3(maux, 1-mbc:maxm+mbc, 3)
 c  -------------------------------------------------
 c       On input,
 c
@@ -434,14 +431,14 @@ c     subroutine rptt3(ixyz,icoor,maxm,meqn,mwaves,mbc,mx,
 c    &                  ql,qr,aux1,aux2,aux3,maux,imp,impt,bsasdq,
 c    &                  cmbsasdq,cpbsasdq)
 c     implicit double precision (a-h,o-z)
-c     dimension      ql(1-mbc:maxm+mbc, meqn)
-c     dimension      qr(1-mbc:maxm+mbc, meqn)
-c     dimension   bsasdq(1-mbc:maxm+mbc, meqn)
-c     dimension cmbsasdq(1-mbc:maxm+mbc, meqn)
-c     dimension cpbsasdq(1-mbc:maxm+mbc, meqn)
-c     dimension   aux1(1-mbc:maxm+mbc, maux, 3)
-c     dimension   aux2(1-mbc:maxm+mbc, maux, 3)
-c     dimension   aux3(1-mbc:maxm+mbc, maux, 3)
+c     dimension      ql(meqn, 1-mbc:maxm+mbc)
+c     dimension      qr(meqn, 1-mbc:maxm+mbc)
+c     dimension   bsasdq(meqn, 1-mbc:maxm+mbc)
+c     dimension cmbsasdq(meqn, 1-mbc:maxm+mbc)
+c     dimension cpbsasdq(meqn, 1-mbc:maxm+mbc)
+c     dimension   aux1(maux, 1-mbc:maxm+mbc, 3)
+c     dimension   aux2(maux, 1-mbc:maxm+mbc, 3)
+c     dimension   aux3(maux, 1-mbc:maxm+mbc, 3)
 c  -------------------------------------------------
 c       On input,
 c
@@ -532,19 +529,19 @@ c           The form of this subroutine is
 c  -------------------------------------------------
 c      subroutine src3(meqn,mbc,mx,my,mz,q,aux,t,dt)
 c      implicit double precision (a-h,o-z)
-c      dimension    q(1-mbc:mx+mbc, 1-mbc:my+mbc,
-c     &               1-mbc:mz+mbc, meqn)
-c      dimension aux(1-mbc:mx+mbc, 1-mbc:my+mbc,
-c     &              1-mbc:mz+mbc, *)
+c      dimension    q(meqn, 1-mbc:mx+mbc, 1-mbc:my+mbc,
+c     &               1-mbc:mz+mbc)
+c      dimension aux(maux, 1-mbc:mx+mbc, 1-mbc:my+mbc,
+c     &              1-mbc:mz+mbc)
 c  -------------------------------------------------
 c      If method(7)=0  or the auxiliary variables are not needed in
 c      this solver,
 c      then the latter dimension statement can be omitted, but aux should
 c      still appear in the argument list.
 c
-c      On input, q(i,j,k,m) contains the data for solving the
+c      On input, q(m,i,j,k) contains the data for solving the
 c                source term equation.
-c      On output, q(i,j,k,m) should have been replaced by the solution to
+c      On output, q(m,i,j,k) should have been replaced by the solution to
 c                 the source term equation after a step of length dt.
 c
 c      b4step3 = subroutine that is called from claw3 before each call to
@@ -556,10 +553,10 @@ c  -------------------------------------------------
 c      subroutine b4step3(mbc,mx,my,mz,meqn,q,
 c    &            xlower,ylower,zlower,dx,dy,dz,time,dt,maux,aux)
 c      implicit double precision (a-h,o-z)
-c      dimension     q(1-mbc:mx+mbc, 1-mbc:my+mbc,
-c     &                1-mbc:mz+mbc, meqn)
-c      dimension   aux(1-mbc:mx+mbc, 1-mbc:my+mbc,
-c     &                1-mbc:mz+mbc, maux)
+c      dimension     q(meqn, 1-mbc:mx+mbc, 1-mbc:my+mbc,
+c     &                1-mbc:mz+mbc)
+c      dimension   aux(maux, 1-mbc:mx+mbc, 1-mbc:my+mbc,
+c     &                1-mbc:mz+mbc)
 c  -------------------------------------------------
 
 c

--- a/src/3d/claw3ez.f
+++ b/src/3d/claw3ez.f
@@ -9,13 +9,12 @@ c     An easy-to-use clawpack driver routine for simple applications
 c     Documentation is available at
 c                 http://www.amath.washington.edu/~claw/doc.html
 c
-c     Author: Randall J. LeVeque
-c     Version of August, 2002 --  CLAWPACK Version 4.1
+c     Author: Randall J. LeVeque, Grady I. Lemoine
 c
-c     Modified July 2013 by Grady Lemoine to use dynamic allocation, new
-c     input file format.  Allocation of all the large arrays (aux, q,
-c     work) is delayed until the last possible moment in case any of the
-c     user code called before them is a memory hog.
+c     Modified July 2013 to use dynamic allocation, new input file
+c     format.  Allocation of all the large arrays (aux, q, work) is
+c     delayed until the last possible moment in case any of the user
+c     code called before them is a memory hog.
 c
       implicit double precision (a-h,o-z)
       external bc3,rpn3,rpt3,rptt3,src3,b4step3

--- a/src/3d/rpn3.f
+++ b/src/3d/rpn3.f
@@ -25,8 +25,8 @@ c     # On output, wave contains the waves, s the speeds,
 c     # and amdq, apdq the left-going and right-going flux differences,
 c     # respectively.  
 c
-c     # Note that the i'th Riemann problem has left state qr(i-1,:)
-c     #                                    and right state ql(i,:)
+c     # Note that the i'th Riemann problem has left state qr(:,i-1)
+c     #                                    and right state ql(:,i)
 c     # From the basic clawpack routines, this routine is called with ql = qr
 c
       implicit real*8(a-h,o-z)

--- a/src/3d/rpt3.f
+++ b/src/3d/rpt3.f
@@ -22,7 +22,7 @@ c     #             in the x-direction if ixyz=1,
 c     #             in the y-direction if ixyz=2, or
 c     #             in the z-direction if ixyz=3.
 c     #    asdq is an array of flux differences (A^*\Dq).
-c     #         asdq(i,:) is the flux difference propagating away from
+c     #         asdq(:,i) is the flux difference propagating away from
 c     #         the interface between cells i-1 and i.
 c     #    Note that asdq represents B^*\Dq if ixyz=2 or C^*\Dq if ixyz=3.
 c
@@ -60,9 +60,9 @@ c
       dimension   asdq(meqn, 1-mbc:maxm+mbc)
       dimension bmasdq(meqn, 1-mbc:maxm+mbc)
       dimension bpasdq(meqn, 1-mbc:maxm+mbc)
-      dimension   aux1(maux, 3, 1-mbc:maxm+mbc)
-      dimension   aux2(maux, 3, 1-mbc:maxm+mbc)
-      dimension   aux3(maux, 3, 1-mbc:maxm+mbc)
+      dimension   aux1(maux, 1-mbc:maxm+mbc, 3)
+      dimension   aux2(maux, 1-mbc:maxm+mbc, 3)
+      dimension   aux3(maux, 1-mbc:maxm+mbc, 3)
 c
       do i = 2-mbc, mx+mbc
          do m=1,meqn

--- a/src/3d/rptt3.f
+++ b/src/3d/rptt3.f
@@ -65,9 +65,9 @@ c
       dimension   bsasdq(meqn, 1-mbc:maxm+mbc)
       dimension cmbsasdq(meqn, 1-mbc:maxm+mbc)
       dimension cpbsasdq(meqn, 1-mbc:maxm+mbc)
-      dimension     aux1(maux, 3, 1-mbc:maxm+mbc)
-      dimension     aux2(maux, 3, 1-mbc:maxm+mbc)
-      dimension     aux3(maux, 3, 1-mbc:maxm+mbc)
+      dimension     aux1(maux, 1-mbc:maxm+mbc, 3)
+      dimension     aux2(maux, 1-mbc:maxm+mbc, 3)
+      dimension     aux3(maux, 1-mbc:maxm+mbc, 3)
 
       do i = 2-mbc, mx+mbc
          do m=1,meqn


### PR DESCRIPTION
This updates the comments in the various Classic sources to reflect the new array indices, addressing issue #27.  It also adds the specific length of the method array to chkmth in 3D.
