### PR TITLE
make plotdata an optional argument in setplot

### DIFF
--- a/examples/acoustics_1d_example1/setplot.py
+++ b/examples/acoustics_1d_example1/setplot.py
@@ -8,7 +8,7 @@ function setplot is called to set the plot parameters.
 """ 
 
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -18,6 +18,9 @@ def setplot(plotdata):
     
     """ 
 
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
 

--- a/examples/acoustics_1d_heterogeneous/setplot.py
+++ b/examples/acoustics_1d_heterogeneous/setplot.py
@@ -1,5 +1,20 @@
 from __future__ import absolute_import
-def setplot(plotdata):
+
+#--------------------------
+def setplot(plotdata=None):
+#--------------------------
+    
+    """ 
+    Specify what is to be plotted at each frame.
+    Input:  plotdata, an instance of clawpack.visclaw.data.ClawPlotData.
+    Output: a modified version of plotdata.
+    
+    """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
+
     plotdata.clearfigures()
 
     # Figures corresponding to Figure 9.5 of LeVeque, "Finite Volume

--- a/examples/acoustics_2d_radial/setplot.py
+++ b/examples/acoustics_2d_radial/setplot.py
@@ -18,7 +18,7 @@ else:
 
 
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -27,6 +27,10 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
 
     from clawpack.visclaw import colormaps

--- a/examples/acoustics_3d_heterogeneous/setplot.py
+++ b/examples/acoustics_3d_heterogeneous/setplot.py
@@ -10,10 +10,10 @@ function setplot is called to set the plot parameters.
     
 """ 
 
+from __future__ import print_function
 
 #--------------------------
-from __future__ import print_function
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -22,6 +22,10 @@ def setplot(plotdata):
     Output: a modified version of plotdata.
     
     """ 
+
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
 
     plotdata.clearfigures()  # clear any old figures,axes,items data

--- a/examples/advection_1d_example1/setplot.py
+++ b/examples/advection_1d_example1/setplot.py
@@ -10,6 +10,7 @@ function setplot is called to set the plot parameters.
 from __future__ import absolute_import
 from __future__ import print_function
 from clawpack.clawutil.data import ClawData
+
 probdata = ClawData()
 probdata.read('setprob.data', force=True)
 print("Parameters: u = %g, beta = %g" % (probdata.u, probdata.beta))
@@ -28,7 +29,7 @@ def qtrue(x,t):
     
 
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -38,6 +39,9 @@ def setplot(plotdata):
     
     """ 
 
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
 

--- a/examples/advection_2d_annulus/setplot.py
+++ b/examples/advection_2d_annulus/setplot.py
@@ -12,7 +12,7 @@ from mapc2p import mapc2p
 import numpy as np
 
 #--------------------------
-def setplot(plotdata):
+def setplot(plotdata=None):
 #--------------------------
     
     """ 
@@ -22,6 +22,9 @@ def setplot(plotdata):
     
     """ 
 
+    if plotdata is None:
+        from clawpack.visclaw.data import ClawPlotData
+        plotdata = ClawPlotData()
 
     from clawpack.visclaw import colormaps
 


### PR DESCRIPTION
So you can do
```
import setplot
plotdata = setplot.setplot()
```
rather than 
```
from clawpack.visclaw.data import ClawPlotData
plotdata = ClawPlotData()
import setplot
plotdata = setplot.setplot(plotdata)
```
which is handy when working in IPython or Jupyter if you want to change attributes of `plotdata` without modifying `setplot.py`.  

I'll make the same change in other repositories.

I also cleaned up some inconsistencies in the headers and ugliness introduced by the Python 3 conversion.