### PR TITLE
remove RESTART from Makefile and comment from setrun.py

### DIFF
--- a/examples/acoustics_1d_example1/Makefile
+++ b/examples/acoustics_1d_example1/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/acoustics_1d_example1/setrun.py
+++ b/examples/acoustics_1d_example1/setrun.py
@@ -86,8 +86,6 @@ def setrun(claw_pkg='classic'):
     
 
     # Restart from checkpoint file of a previous run?
-    # Note: If restarting, you must also change the Makefile to set:
-    #    RESTART = True
     # If restarting, t0 above should be from original run, and the
     # restart_file 'fort.qNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.

--- a/examples/acoustics_1d_heterogeneous/Makefile
+++ b/examples/acoustics_1d_heterogeneous/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/acoustics_1d_heterogeneous/setrun.py
+++ b/examples/acoustics_1d_heterogeneous/setrun.py
@@ -89,8 +89,6 @@ def setrun(claw_pkg='classic'):
     
 
     # Restart from checkpoint file of a previous run?
-    # Note: If restarting, you must also change the Makefile to set:
-    #    RESTART = True
     # If restarting, t0 above should be from original run, and the
     # restart_file 'fort.qNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.

--- a/examples/acoustics_2d_radial/1drad/setrun.py
+++ b/examples/acoustics_2d_radial/1drad/setrun.py
@@ -85,8 +85,6 @@ def setrun(claw_pkg='classic'):
     
 
     # Restart from checkpoint file of a previous run?
-    # Note: If restarting, you must also change the Makefile to set:
-    #    RESTART = True
     # If restarting, t0 above should be from original run, and the
     # restart_file 'fort.qNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.

--- a/examples/acoustics_2d_radial/Makefile
+++ b/examples/acoustics_2d_radial/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/acoustics_2d_radial/setrun.py
+++ b/examples/acoustics_2d_radial/setrun.py
@@ -94,8 +94,6 @@ def setrun(claw_pkg='classic'):
     
 
     # Restart from checkpoint file of a previous run?
-    # Note: If restarting, you must also change the Makefile to set:
-    #    RESTART = True
     # If restarting, t0 above should be from original run, and the
     # restart_file 'fort.chkNNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.

--- a/examples/acoustics_3d_heterogeneous/Makefile
+++ b/examples/acoustics_3d_heterogeneous/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/acoustics_3d_heterogeneous/setrun.py
+++ b/examples/acoustics_3d_heterogeneous/setrun.py
@@ -92,8 +92,6 @@ def setrun(claw_pkg='classic'):
     
 
     # Restart from checkpoint file of a previous run?
-    # Note: If restarting, you must also change the Makefile to set:
-    #    RESTART = True
     # If restarting, t0 above should be from original run, and the
     # restart_file 'fort.chkNNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.

--- a/examples/advection_1d_example1/Makefile
+++ b/examples/advection_1d_example1/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/advection_1d_example1/setrun.py
+++ b/examples/advection_1d_example1/setrun.py
@@ -85,8 +85,6 @@ def setrun(claw_pkg='classic'):
     
 
     # Restart from checkpoint file of a previous run?
-    # Note: If restarting, you must also change the Makefile to set:
-    #    RESTART = True
     # If restarting, t0 above should be from original run, and the
     # restart_file 'fort.qNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.

--- a/examples/advection_2d_annulus/Makefile
+++ b/examples/advection_2d_annulus/Makefile
@@ -20,7 +20,6 @@ SETPLOT_FILE = setplot.py           # File containing function to set plots
 PLOTDIR = _plots                    # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
-RESTART ?= False                    # Should = clawdata.restart in setrun
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/examples/advection_2d_annulus/setrun.py
+++ b/examples/advection_2d_annulus/setrun.py
@@ -94,8 +94,6 @@ def setrun(claw_pkg='classic'):
     
 
     # Restart from checkpoint file of a previous run?
-    # Note: If restarting, you must also change the Makefile to set:
-    #    RESTART = True
     # If restarting, t0 above should be from original run, and the
     # restart_file 'fort.qNNNN' specified below should be in 
     # the OUTDIR indicated in Makefile.


### PR DESCRIPTION
Consistent with improvements made in clawpack/clawutil@0f6dbaebf6d2, so you no longer need to change RESTART variable in Makefile when doing a restart.

The same changes will be made in other PRs in amrclaw and geoclaw, and I will update the docs.