### PR TITLE
try python 3.6.10 for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - 2.7
-  - 3.5
+  - 3.6.10
 env:
   - BUILD_TYPE="Release"
   


### PR DESCRIPTION
Try this since https://github.com/clawpack/clawpack/pull/182 fails with 3.5 and this fix earlier worked for geoclaw.