### PR TITLE
Modify src/Nd/outN.f to write out mbc,file_format in fort.t files

### DIFF
--- a/examples/acoustics_1d_example1/setrun.py
+++ b/examples/acoustics_1d_example1/setrun.py
@@ -122,7 +122,8 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii' is only option currently
+
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/examples/acoustics_1d_heterogeneous/setrun.py
+++ b/examples/acoustics_1d_heterogeneous/setrun.py
@@ -125,7 +125,7 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii' is only option currently
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/examples/acoustics_2d_radial/setrun.py
+++ b/examples/acoustics_2d_radial/setrun.py
@@ -130,7 +130,8 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format = 'ascii'       # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii' is only option currently
+
 
 
     # ---------------------------------------------------

--- a/examples/acoustics_3d_heterogeneous/setrun.py
+++ b/examples/acoustics_3d_heterogeneous/setrun.py
@@ -128,7 +128,7 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii' is only option currently
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/examples/advection_1d_example1/setrun.py
+++ b/examples/advection_1d_example1/setrun.py
@@ -121,7 +121,7 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii' is only option currently
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/examples/advection_2d_annulus/setrun.py
+++ b/examples/advection_2d_annulus/setrun.py
@@ -130,7 +130,7 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii' is only option currently
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/examples/euler_1d_wcblast/setrun.py
+++ b/examples/euler_1d_wcblast/setrun.py
@@ -120,7 +120,7 @@ def setrun(claw_pkg='classic'):
         clawdata.output_t0 = True  # output at initial (or restart) time?
         
 
-    clawdata.output_format = 'ascii'      # 'ascii', 'binary', 'netcdf'
+    clawdata.output_format = 'ascii'      # 'ascii' is only option currently
 
     clawdata.output_q_components = 'all'   # could be list such as [True,True]
     clawdata.output_aux_components = 'none'  # could be list

--- a/src/1d/out1.f
+++ b/src/1d/out1.f
@@ -20,6 +20,9 @@ c
       dimension aux(maux,1-mbc:mx+mbc)
       character*10 fname1, fname2, fname3
       logical outaux
+      character(len=8) :: file_format
+
+      file_format = 'ascii'  ! only format currently supported
 
 c     
 c     # Write the results to the file fort.q<iframe>
@@ -94,13 +97,15 @@ c
          close(unit=70)
       endif
 
-      write(60,1000) t,meqn,ngrids,maux,1
+      write(60,1000) t,meqn,ngrids,maux,1,mbc,file_format
 
  1000 format(e26.16,'    time', /,
      &     i5,'                 meqn'/,
      &     i5,'                 ngrids'/,
      &     i5,'                 maux'/,
-     &     i5,'                 ndim'/,/)
+     &     i5,'                 ndim'/,
+     &     i5,'                 nghost'/,
+     &     a10,'                 format'/,/)
 c     
 
       close(unit=50)

--- a/src/2d/out2.f
+++ b/src/2d/out2.f
@@ -22,7 +22,9 @@ c
       logical, intent(in) :: outaux
 
       character*10 fname1, fname2, fname3
+      character(len=8) :: file_format
 
+      file_format = 'ascii'  ! only format currently supported
 c
 c     # first create the file name and open file
 c
@@ -98,13 +100,15 @@ c
       close(unit=70)
       endif
 
-      write(60,1000) t,meqn,ngrids,maux,2
+      write(60,1000) t,meqn,ngrids,maux,2,mbc,file_format
 
  1000 format(e26.16,'    time', /,
      &       i5,'                 meqn'/,
      &       i5,'                 ngrids'/,
      &       i5,'                 maux'/,
-     &       i5,'                 ndim'/,/)
+     &       i5,'                 ndim'/,
+     &       i5,'                 nghost'/,
+     &       a10,'                 format'/,/)
 c
       close(unit=50)
       close(unit=60)

--- a/src/3d/out3.f
+++ b/src/3d/out3.f
@@ -23,6 +23,9 @@ c
      &               1-mbc:mz+mbc)
       logical, intent(in) :: outaux
       character*10 fname1, fname2, fname3
+      character(len=8) :: file_format
+
+      file_format = 'ascii'  ! only format currently supported
 
 c
 c
@@ -109,13 +112,15 @@ c
       close(unit=70)
       endif
 
-      write(60,1000) t,meqn,ngrids,maux,3
+      write(60,1000) t,meqn,ngrids,maux,3,mbc,file_format
 
  1000 format(e26.16,'    time', /,
      &       i5,'                 meqn'/,
      &       i5,'                 ngrids'/,
      &       i5,'                 maux'/,
-     &       i5,'                 ndim'/,/)
+     &       i5,'                 ndim'/,
+     &       i5,'                 nghost'/,
+     &       a10,'                 format'/,/)
 c
 
       close(unit=50)


### PR DESCRIPTION
In order to match amrclaw, geoclaw and work with pyclaw code for reading the files.
This is required in order to use https://github.com/clawpack/pyclaw/pull/687 with classic output.

Note that only ascii format is currently supported, so also I also fixed the comment in setrun.py files.