### PR TITLE
Change how `aux` arrays are passed through to `rpn3`

### DIFF
--- a/src/3d/flux3.f90
+++ b/src/3d/flux3.f90
@@ -203,7 +203,7 @@
 !     # aux2(1-num_ghost,1,2) is the start of a 1d array now used by rpn3
 
     call rpn3(ixyz,maxm,num_eqn,num_waves,num_aux,num_ghost,mx,q1d,q1d, &
-    aux2(1,1-num_ghost,2),aux2(1,1-num_ghost,2), &
+    aux2(:,1-num_ghost,2),aux2(:,1-num_ghost,2), &
     wave,s,amdq,apdq)
 
 
@@ -610,5 +610,3 @@
 
     return
     end subroutine flux3
-
-


### PR DESCRIPTION
Noticed that now some compilers will not allow the call to rpn3 to include explicit mention to `aux2`.  The original line is:
```fortran
call rpn3(ixyz,maxm,num_eqn,num_waves,num_aux,num_ghost,mx,q1d,q1d, &
          aux2(1,1-num_ghost,2),aux2(1,1-num_ghost,2), &
          wave,s,amdq,apdq)
```
Instead use `:` to pass array in case `maux=0`:
```fortran
call rpn3(..., aux2(:,1-num_ghost,2), aux2(:,1-num_ghost,2), ...)
```
This was the only line it complained about, but there may be other places this should be changed.  This is also fixed in clawpack/pyclaw#748.